### PR TITLE
[feat] 메뉴 전체/상세 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/controller/MenuController.java
+++ b/src/main/java/org/sopt/controller/MenuController.java
@@ -2,12 +2,10 @@ package org.sopt.controller;
 
 import org.sopt.dto.common.BaseResponse;
 import org.sopt.dto.response.MenuListResponse;
+import org.sopt.dto.response.MenuResponse;
 import org.sopt.dto.type.SuccessMessage;
 import org.sopt.service.MenuService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(value = "/api/v1/menu")
@@ -23,5 +21,13 @@ public class MenuController {
             @RequestHeader Long userId
     ) {
         return BaseResponse.success(SuccessMessage.OK, menuService.getMenuList(userId));
+    }
+
+    @GetMapping("/{menuId}")
+    public BaseResponse<MenuResponse> getMenuDetail(
+            @RequestHeader Long userId,
+            @PathVariable("menuId") Long menuId
+    ){
+        return BaseResponse.success(SuccessMessage.OK, menuService.getMenuDetail(userId, menuId));
     }
 }

--- a/src/main/java/org/sopt/controller/MenuController.java
+++ b/src/main/java/org/sopt/controller/MenuController.java
@@ -1,0 +1,27 @@
+package org.sopt.controller;
+
+import org.sopt.dto.common.BaseResponse;
+import org.sopt.dto.response.MenuListResponse;
+import org.sopt.dto.type.SuccessMessage;
+import org.sopt.service.MenuService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/v1/menu")
+public class MenuController {
+    private final MenuService menuService;
+
+    protected MenuController(MenuService menuService) {
+        this.menuService = menuService;
+    }
+
+    @GetMapping()
+    public BaseResponse<MenuListResponse> getMenuList(
+            @RequestHeader Long userId
+    ) {
+        return BaseResponse.success(SuccessMessage.OK, menuService.getMenuList(userId));
+    }
+}

--- a/src/main/java/org/sopt/controller/UserController.java
+++ b/src/main/java/org/sopt/controller/UserController.java
@@ -1,0 +1,7 @@
+package org.sopt.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+}

--- a/src/main/java/org/sopt/domain/Menu.java
+++ b/src/main/java/org/sopt/domain/Menu.java
@@ -1,0 +1,50 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Menu {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long menuId;
+    private String menuName;
+    private String singleImgUrl;
+    private String setImgUrl;
+    private Integer singlePrice;
+    private Integer setPrice;
+
+    protected Menu() {
+    }
+
+    public Menu(String menuName, String singleImgUrl, String setImgUrl, Integer singlePrice, Integer setPrice) {
+        this.menuName = menuName;
+        this.singleImgUrl = singleImgUrl;
+        this.setImgUrl = setImgUrl;
+        this.singlePrice = singlePrice;
+        this.setPrice = setPrice;
+    }
+
+    public Long getMenuId() {
+        return menuId;
+    }
+
+    public String getMenuName() {
+        return menuName;
+    }
+
+    public String getSingleImgUrl() {
+        return singleImgUrl;
+    }
+
+    public String getSetImgUrl() {
+        return setImgUrl;
+    }
+
+    public Integer getSinglePrice() {
+        return singlePrice;
+    }
+
+    public Integer getSetPrice() {
+        return setPrice;
+    }
+}

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -1,0 +1,13 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    protected User() {
+    }
+}

--- a/src/main/java/org/sopt/dto/response/MenuListResponse.java
+++ b/src/main/java/org/sopt/dto/response/MenuListResponse.java
@@ -1,0 +1,15 @@
+package org.sopt.dto.response;
+
+import java.util.List;
+
+public record MenuListResponse(
+        List<MenuSummary> menuList
+) {
+    public record MenuSummary(
+            Long menuId,
+            String menuName,
+            String menuImg,
+            String menuPrice
+    ) {
+    }
+}

--- a/src/main/java/org/sopt/dto/response/MenuResponse.java
+++ b/src/main/java/org/sopt/dto/response/MenuResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.dto.response;
+
+public record MenuResponse(
+        Long menuId,
+        String menuName,
+        String singleImg,
+        String singlePrice,
+        String setImg,
+        String setPrice
+) {
+}

--- a/src/main/java/org/sopt/repository/MenuJpaRepository.java
+++ b/src/main/java/org/sopt/repository/MenuJpaRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MenuJpaRepository extends JpaRepository<Menu, Long> {
+}

--- a/src/main/java/org/sopt/repository/UserJpaRepository.java
+++ b/src/main/java/org/sopt/repository/UserJpaRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.repository;
+
+import org.sopt.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/org/sopt/service/MenuService.java
+++ b/src/main/java/org/sopt/service/MenuService.java
@@ -1,0 +1,42 @@
+package org.sopt.service;
+
+import org.sopt.domain.Menu;
+import org.sopt.dto.response.MenuListResponse;
+import org.sopt.dto.type.ErrorMessage;
+import org.sopt.exception.CustomException;
+import org.sopt.repository.MenuJpaRepository;
+import org.sopt.repository.UserJpaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MenuService {
+    private final MenuJpaRepository menuRepository;
+    private final UserJpaRepository userRepository;
+
+    protected MenuService(final MenuJpaRepository menuRepository, final UserJpaRepository UserRepository) {
+        this.menuRepository = menuRepository;
+        this.userRepository = UserRepository;
+    }
+
+    public MenuListResponse getMenuList(Long userId) {
+        validateUserIdExist(userId);
+        List<Menu> menuList = menuRepository.findAll();
+        List<MenuListResponse.MenuSummary> menuSummaries = menuList.stream()
+                .map(menu -> new MenuListResponse.MenuSummary(
+                        menu.getMenuId(),
+                        menu.getMenuName(),
+                        menu.getSingleImgUrl(),
+                        "₩" + menu.getSinglePrice().toString() + " ~"
+                ))
+                .toList();
+        return new MenuListResponse(menuSummaries);
+    }
+
+    private void validateUserIdExist(Long userId){
+        if (!userRepository.existsById(userId)) {
+            throw new CustomException(ErrorMessage.UNAUTHORIZED_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/sopt/service/MenuService.java
+++ b/src/main/java/org/sopt/service/MenuService.java
@@ -10,6 +10,7 @@ import org.sopt.repository.UserJpaRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.text.NumberFormat;
 
 @Service
 public class MenuService {
@@ -29,7 +30,7 @@ public class MenuService {
                         menu.getMenuId(),
                         menu.getMenuName(),
                         menu.getSingleImgUrl(),
-                        "₩" + menu.getSinglePrice().toString() + " ~"
+                        "₩" + NumberFormat.getInstance().format(menu.getSinglePrice()) + " ~"
                 ))
                 .toList();
         return new MenuListResponse(menuSummaries);
@@ -42,9 +43,9 @@ public class MenuService {
                         menu.getMenuId(),
                         menu.getMenuName(),
                         menu.getSingleImgUrl(),
-                        "₩" + menu.getSinglePrice().toString(),
+                        "₩" + NumberFormat.getInstance().format(menu.getSinglePrice()),
                         menu.getSetImgUrl(),
-                        "₩" + menu.getSetPrice().toString()
+                        "₩" + NumberFormat.getInstance().format(menu.getSetPrice())
                 ))
                 .orElseThrow(() -> new CustomException(ErrorMessage.NOT_FOUND_ERROR));
     }

--- a/src/main/java/org/sopt/service/MenuService.java
+++ b/src/main/java/org/sopt/service/MenuService.java
@@ -2,6 +2,7 @@ package org.sopt.service;
 
 import org.sopt.domain.Menu;
 import org.sopt.dto.response.MenuListResponse;
+import org.sopt.dto.response.MenuResponse;
 import org.sopt.dto.type.ErrorMessage;
 import org.sopt.exception.CustomException;
 import org.sopt.repository.MenuJpaRepository;
@@ -32,6 +33,20 @@ public class MenuService {
                 ))
                 .toList();
         return new MenuListResponse(menuSummaries);
+    }
+
+    public MenuResponse getMenuDetail(Long userId, Long menuId) {
+        validateUserIdExist(userId);
+        return menuRepository.findById(menuId)
+                .map(menu -> new MenuResponse(
+                        menu.getMenuId(),
+                        menu.getMenuName(),
+                        menu.getSingleImgUrl(),
+                        "₩" + menu.getSinglePrice().toString(),
+                        menu.getSetImgUrl(),
+                        "₩" + menu.getSetPrice().toString()
+                ))
+                .orElseThrow(() -> new CustomException(ErrorMessage.NOT_FOUND_ERROR));
     }
 
     private void validateUserIdExist(Long userId){

--- a/src/main/java/org/sopt/service/UserService.java
+++ b/src/main/java/org/sopt/service/UserService.java
@@ -1,0 +1,7 @@
+package org.sopt.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #4 

## Work Description ✏️
- 메뉴 전체 조회 API
- 메뉴 상세 조회 API
- 에러 핸들링

## Screenshot 📸

### 메뉴 전체 조회 API
1. 성공
<img width="622" alt="image" src="https://github.com/user-attachments/assets/1ebf4d02-149e-4459-9389-e3f625fdd19b" />

2. `404` 유효하지 않은 헤더
<img width="612" alt="image" src="https://github.com/user-attachments/assets/1e168526-7591-4110-be7c-983d7fb98aff" />

3. `401` 인증 오류 
ex. 1~6의 userId가 아닐 때
<img width="619" alt="image" src="https://github.com/user-attachments/assets/0993b0c6-87d5-4fa7-896c-27f0086903cc" />

4. `405` 지원하지 않는 메소드
<img width="605" alt="image" src="https://github.com/user-attachments/assets/b2b0a8cd-a73a-4f27-8d13-a751b069563e" />

### 메뉴 상세 조회 API
1. 성공
<img width="610" alt="image" src="https://github.com/user-attachments/assets/61e56232-770b-4e01-ad10-ba1933643c0f" />

2. `404` 유효하지 않은 헤더
<img width="609" alt="image" src="https://github.com/user-attachments/assets/5b8b3d6c-8159-45a2-8b65-769deefd8d76" />

3. `401` 인증 오류 
ex. 1~6의 userId가 아닐 때
<img width="604" alt="image" src="https://github.com/user-attachments/assets/0d65e3ca-4640-4960-8d2b-5f50b5a54488" />

4. `405` 지원하지 않는 메소드
<img width="629" alt="image" src="https://github.com/user-attachments/assets/ede72633-efa0-49f8-9137-3ef3083dd101" />

## To Reviewers 📢
세미나에서 배운대로 Lombok을 안 쓰고 Getter, Setter 전부 다 직접 구현했는데 쓰는게 좋을까요?
이참에 배워봐야 될 것 같기두!