### PR TITLE
[FEAT] 주문 완료 API

### DIFF
--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -2,8 +2,10 @@ package org.sopt;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
+@EntityScan("org.sopt.domain")
 public class Main {
     public static void main(String[] args) {
         SpringApplication.run(Main.class, args);

--- a/src/main/java/org/sopt/controller/OrderController.java
+++ b/src/main/java/org/sopt/controller/OrderController.java
@@ -1,0 +1,30 @@
+package org.sopt.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.dto.common.BaseResponse;
+import org.sopt.dto.request.CreateOrderRequest;
+import org.sopt.dto.type.SuccessMessage;
+import org.sopt.service.OrderService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/order")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> createOrder(
+            @RequestHeader Long userId,
+            @RequestBody @Valid CreateOrderRequest request
+    ){
+        orderService.createOrder(userId, request);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(SuccessMessage.OK, null)
+        );
+    }
+}

--- a/src/main/java/org/sopt/controller/OrderController.java
+++ b/src/main/java/org/sopt/controller/OrderController.java
@@ -18,10 +18,9 @@ public class OrderController {
 
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> createOrder(
-            @RequestHeader Long userId,
-            @RequestBody @Valid CreateOrderRequest request
+            @RequestHeader Long userId
     ){
-        orderService.createOrder(userId, request);
+        orderService.createOrder(userId);
 
         return ResponseEntity.ok(
                 BaseResponse.success(SuccessMessage.OK, null)

--- a/src/main/java/org/sopt/domain/Menu.java
+++ b/src/main/java/org/sopt/domain/Menu.java
@@ -19,6 +19,9 @@ public class Menu {
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<CartItem> cartItems;
 
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<OrderDetail> orderDetails;
+
     protected Menu() {
     }
 

--- a/src/main/java/org/sopt/domain/Order.java
+++ b/src/main/java/org/sopt/domain/Order.java
@@ -1,0 +1,37 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "`order`")
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long orderId;
+
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<OrderDetail> orderDetails;
+
+    public static Order create(
+            User user
+    ){
+        return Order.builder()
+                .user(user)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/domain/OrderDetail.java
+++ b/src/main/java/org/sopt/domain/OrderDetail.java
@@ -1,0 +1,39 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderDetail {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long orderDetailId;
+    private Boolean isSet;
+    private Integer amount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    public static OrderDetail create(
+            Order order,
+            Menu menu,
+            Boolean isSet,
+            Integer amount
+    ){
+        return OrderDetail.builder()
+                .order(order)
+                .menu(menu)
+                .isSet(isSet)
+                .amount(amount)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/dto/request/CreateOrderRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreateOrderRequest.java
@@ -1,0 +1,11 @@
+package org.sopt.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record CreateOrderRequest(
+        @NotEmpty List<Long> cartItemIds
+) {
+
+}

--- a/src/main/java/org/sopt/dto/request/CreateOrderRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreateOrderRequest.java
@@ -5,7 +5,5 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 public record CreateOrderRequest(
-        @NotEmpty List<Long> cartItemIds
 ) {
-
 }

--- a/src/main/java/org/sopt/repository/OrderDetailJpaRepository.java
+++ b/src/main/java/org/sopt/repository/OrderDetailJpaRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.repository;
+
+import org.sopt.domain.OrderDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderDetailJpaRepository extends JpaRepository<OrderDetail, Long> {
+}

--- a/src/main/java/org/sopt/repository/OrderJpaRepository.java
+++ b/src/main/java/org/sopt/repository/OrderJpaRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderJpaRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/org/sopt/service/OrderService.java
+++ b/src/main/java/org/sopt/service/OrderService.java
@@ -1,0 +1,60 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.CartItem;
+import org.sopt.domain.Order;
+import org.sopt.domain.OrderDetail;
+import org.sopt.domain.User;
+import org.sopt.dto.request.CreateOrderRequest;
+import org.sopt.dto.type.ErrorMessage;
+import org.sopt.exception.CustomException;
+import org.sopt.repository.CartItemRepository;
+import org.sopt.repository.OrderDetailJpaRepository;
+import org.sopt.repository.OrderJpaRepository;
+import org.sopt.repository.UserJpaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderDetailJpaRepository orderDetailJpaRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final CartItemRepository cartItemRepository;
+
+    private final OrderJpaRepository orderJpaRepository;
+
+    @Transactional
+    public void createOrder(Long userId, CreateOrderRequest request) {
+        User user = getUser(userId);
+
+        Order order = Order.create(user);
+        orderJpaRepository.save(order);
+
+        List<CartItem> cartItems = cartItemRepository.findAllById(request.cartItemIds());
+        if (cartItems.size() != request.cartItemIds().size()) {
+            throw new CustomException(ErrorMessage.NOT_FOUND_ERROR);
+        }
+
+        List<OrderDetail> orderDetails = cartItems.stream()
+                .map(cartItem -> OrderDetail.create(
+                        order,
+                        cartItem.getMenu(),
+                        cartItem.getIsSet(),
+                        cartItem.getAmount()
+                ))
+                .toList();
+        orderDetailJpaRepository.saveAll(orderDetails);
+
+        cartItemRepository.deleteAll(cartItems);
+    }
+
+    private User getUser(Long userId) {
+        return userJpaRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorMessage.INVALID_HEADER_ERROR));
+    }
+}

--- a/src/main/java/org/sopt/service/OrderService.java
+++ b/src/main/java/org/sopt/service/OrderService.java
@@ -29,14 +29,14 @@ public class OrderService {
     private final OrderJpaRepository orderJpaRepository;
 
     @Transactional
-    public void createOrder(Long userId, CreateOrderRequest request) {
+    public void createOrder(Long userId) {
         User user = getUser(userId);
 
         Order order = Order.create(user);
         orderJpaRepository.save(order);
 
-        List<CartItem> cartItems = cartItemRepository.findAllById(request.cartItemIds());
-        if (cartItems.size() != request.cartItemIds().size()) {
+        List<CartItem> cartItems = cartItemRepository.findAllByUser(user);
+        if (cartItems.isEmpty()) {
             throw new CustomException(ErrorMessage.NOT_FOUND_ERROR);
         }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #7 

## Work Description ✏️
- 주문 완료 API 구현

## Screenshot 📸
1. 포스트맨
![image](https://github.com/user-attachments/assets/d36727b0-a5bc-4865-8723-434130db3325)

2. 성공 시, order Table
![image](https://github.com/user-attachments/assets/be07e5c9-1d55-4d7a-a9e1-d773d9b7c22d)

3. 성공 시, order_detail Table
![image](https://github.com/user-attachments/assets/29916f68-71c5-4058-b897-1f3dd606c5df)

4. 깨끗하게 삭제된 cart_item Table
![image](https://github.com/user-attachments/assets/6f14e31f-6162-4c36-885e-08c24b09a2c4)

## To Reviewers 📢
**주요 변경 사항**
RequestBody로 cartItemIds를 리스트로 받기로 했었는데, 생각해보니 장바구니에서 선택해서 최종 주문하는 기능이 없더라구요..?
카트 아이템 각각의 아이디 값을 요청하는게 클라한테 더 번거로울 것 같아서 userId만 헤더로 보내주면 사용자가 들고 있는 장바구니 아이템 모두 주문하는 기능으로 변경했습니다! --> 노션 변경 완료 했습니당 ㅎㅎ