### PR TITLE
[FEAT] 장바구니 품목 개수 수정 API 구현

### DIFF
--- a/src/main/java/org/sopt/controller/CartItemController.java
+++ b/src/main/java/org/sopt/controller/CartItemController.java
@@ -5,16 +5,12 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.sopt.dto.common.BaseResponse;
 import org.sopt.dto.request.CreateCartItemRequest;
+import org.sopt.dto.request.UpdateCartItemRequest;
 import org.sopt.dto.response.GetCartItemListResponse;
 import org.sopt.dto.type.SuccessMessage;
 import org.sopt.service.CartItemService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/cart")
@@ -47,5 +43,18 @@ public class CartItemController {
         );
     }
 
+
+    @PostMapping("/{cartItemId}")
+    public ResponseEntity<BaseResponse<Void>> updateCartItemAmount(
+            @RequestHeader Long userId,
+            @PathVariable Long cartItemId,
+            @RequestBody@Valid UpdateCartItemRequest request
+    ) {
+        cartItemService.updateCartItemAmount(userId, cartItemId, request.amount());
+
+        return ResponseEntity.ok(
+                BaseResponse.success(SuccessMessage.OK, null)
+        );
+    }
 
 }

--- a/src/main/java/org/sopt/controller/OrderController.java
+++ b/src/main/java/org/sopt/controller/OrderController.java
@@ -3,7 +3,6 @@ package org.sopt.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.dto.common.BaseResponse;
-import org.sopt.dto.request.CreateOrderRequest;
 import org.sopt.dto.type.SuccessMessage;
 import org.sopt.service.OrderService;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/sopt/domain/CartItem.java
+++ b/src/main/java/org/sopt/domain/CartItem.java
@@ -52,4 +52,11 @@ public class CartItem {
                 .build();
     }
 
+    public void updateAmount(Integer amount) {
+        this.amount = amount;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.user.getUserId().equals(userId);
+    }
 }

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -1,9 +1,15 @@
 package org.sopt.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.util.List;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class User {
 
     @Id
@@ -12,7 +18,4 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     List<CartItem> cartItems;
-
-    protected User() {
-    }
 }

--- a/src/main/java/org/sopt/dto/request/CreateOrderRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreateOrderRequest.java
@@ -1,9 +1,0 @@
-package org.sopt.dto.request;
-
-import jakarta.validation.constraints.NotEmpty;
-
-import java.util.List;
-
-public record CreateOrderRequest(
-) {
-}

--- a/src/main/java/org/sopt/dto/request/UpdateCartItemRequest.java
+++ b/src/main/java/org/sopt/dto/request/UpdateCartItemRequest.java
@@ -1,0 +1,8 @@
+package org.sopt.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateCartItemRequest(
+        @NotNull Integer amount
+) {
+}

--- a/src/main/java/org/sopt/service/CartItemService.java
+++ b/src/main/java/org/sopt/service/CartItemService.java
@@ -44,6 +44,20 @@ public class CartItemService {
         cartItemRepository.save(cartItem);
     }
 
+    @Transactional
+    public void updateCartItemAmount(Long userId, Long cartItemId, Integer newAmount) {
+        User user = getUser(userId);
+
+        CartItem cartItem = cartItemRepository.findById(cartItemId)
+                .orElseThrow(() -> new CustomException(ErrorMessage.NOT_FOUND_ERROR));
+
+        if (!cartItem.isOwnedBy(userId)) {
+            throw new CustomException(ErrorMessage.UNAUTHORIZED_ERROR);
+        }
+
+        cartItem.updateAmount(newAmount);
+    }
+
     public List<CartItemDto> getAllCartItems(Long userId) {
         User user = getUser(userId);
 

--- a/src/main/java/org/sopt/service/OrderService.java
+++ b/src/main/java/org/sopt/service/OrderService.java
@@ -5,7 +5,6 @@ import org.sopt.domain.CartItem;
 import org.sopt.domain.Order;
 import org.sopt.domain.OrderDetail;
 import org.sopt.domain.User;
-import org.sopt.dto.request.CreateOrderRequest;
 import org.sopt.dto.type.ErrorMessage;
 import org.sopt.exception.CustomException;
 import org.sopt.repository.CartItemRepository;


### PR DESCRIPTION
## Related issue 🛠
- closed #10 

## Work Description ✏️
- 장바구니 품목 개수 수정 API 구현

## Screenshot 📸
1. 포스트맨
![image](https://github.com/user-attachments/assets/0defe8d6-3c92-49e7-b137-c0a5057ed814)

2. 기존 cart_item Table
![image](https://github.com/user-attachments/assets/52c4a5d4-de7a-4759-830e-c93331b2ff5e)

3. 성공 시, cart_item Table
![image](https://github.com/user-attachments/assets/83a379f3-fd11-4799-b91b-320230ae12d4)

## To Reviewers 📢